### PR TITLE
Proper implementation of closeInventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,23 @@ final Element backgroundElement = new BasicElement(
 final List<Element> playerHeads =
     new PlayerHeads(PlayerType.STAFF);
 
+// this is the exit button used to close the inventory
+// it uses a local class and the bukkit scheduler
+// in order to close the inventory properly
+// https://hub.spigotmc.org/javadocs/spigot/org/bukkit/scheduler/BukkitScheduler.html
 final Element exitButton = new BasicElement(
     new ItemStack(Material.BARRIER),
     event -> {
         event.setCancelled(true);
-        event.getWhoClicked.closeInventory();
+        
+        class CloseInventoryTask implements Runnable {
+            @Override
+            public void run() {
+                event.getWhoClicked().closeInventory();
+            }
+        }
+        Bukkit.getScheduler().runTask(
+            Bukkit.getPluginManager().getPlugin("myPluginsName"), new CloseInventoryTask());
     }
 );
 

--- a/README.md
+++ b/README.md
@@ -135,23 +135,13 @@ final Element backgroundElement = new BasicElement(
 final List<Element> playerHeads =
     new PlayerHeads(PlayerType.STAFF);
 
-// this is the exit button used to close the inventory
-// it uses a local class and the bukkit scheduler
-// in order to close the inventory properly
-// https://hub.spigotmc.org/javadocs/spigot/org/bukkit/scheduler/BukkitScheduler.html
 final Element exitButton = new BasicElement(
     new ItemStack(Material.BARRIER),
     event -> {
         event.setCancelled(true);
-        
-        class CloseInventoryTask implements Runnable {
-            @Override
-            public void run() {
-                event.getWhoClicked().closeInventory();
-            }
-        }
-        Bukkit.getScheduler().runTask(
-            Bukkit.getPluginManager().getPlugin("myPluginsName"), new CloseInventoryTask());
+        // this is not how you should close your inventory.
+        // please do read here: https://github.com/Personinblack/black/pull/2
+        event.getWhoClicked.closeInventory();
     }
 );
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ final Element exitButton = new BasicElement(
     new ItemStack(Material.BARRIER),
     event -> {
         event.setCancelled(true);
+        
         // this is not how you should close your inventory.
         // please do read here: https://github.com/Personinblack/black/pull/2
         event.getWhoClicked.closeInventory();


### PR DESCRIPTION
Based on the [Spigot Documentation](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/event/inventory/InventoryClickEvent.html) you should not call closeInventory inside of the InventoryClickEvent. I added a proper implementation for closing the inventory.
I found a local class to be the easiest for that example.

BTW: very nice Library 👍 
Learned a lot while reading your code :)